### PR TITLE
Improve stability and performance

### DIFF
--- a/src/comps/csv/parse.js
+++ b/src/comps/csv/parse.js
@@ -29,6 +29,12 @@ function parseCsv(path) {
             return
         }
 
+        // Skip the row if any value is empty
+        if (values.some((value) => !value)) {
+            console.log("Skipping row with empty value(s):", row);
+            return;
+        }
+
         let obj = createObject(keys, values)
         result.push(obj)
     })

--- a/src/comps/csv/parse.js
+++ b/src/comps/csv/parse.js
@@ -20,10 +20,16 @@ function parseCsv(path) {
     let firstRow = rows.shift()
     let keys = firstRow.split(",").map(cleanText)
 
-    rows.forEach((x) => {
-        x = x.split(",").map(cleanText)
-        if (x.some((p) => !p)) return
-        let obj = createObject(keys, x)
+    rows.forEach((row) => {
+        let values = row.split(",").map(cleanText)
+
+        // Skip the row if the number of values doesn't match the number of keys
+        if (values.length !== keys.length) {
+            // console.log("Skipping invalid row:", row)
+            return
+        }
+
+        let obj = createObject(keys, values)
         result.push(obj)
     })
 

--- a/src/comps/update/sync.js
+++ b/src/comps/update/sync.js
@@ -35,7 +35,6 @@ async function sync(dataDir, roundNumber) {
     if (round_hash_map[roundNumber] == hashsum) {
         return console.log("No changes detected, skipping round", roundNumber)
     }
-    round_hash_map[roundNumber] = hashsum
 
     try {
         nftinfo = parsePurgatory(nftinfo)
@@ -99,6 +98,7 @@ async function sync(dataDir, roundNumber) {
         challenge_rewards,
         roundNumber: roundNumber
     })
+    round_hash_map[roundNumber] = hashsum
 }
 
 module.exports = { sync }

--- a/src/cron/main.js
+++ b/src/cron/main.js
@@ -43,7 +43,7 @@ async function sync_historical() {
 
     const folders = fs.readdirSync(histDataDir);
 
-    const maxConcurrency = 30;
+    const maxConcurrency = 1
 
     async function runWithConcurrency(tasks) {
         const results = [];

--- a/test/csv_parse.test.js
+++ b/test/csv_parse.test.js
@@ -59,4 +59,26 @@ describe("Testing CSV Parser", () => {
         const result = parseCsv("some_path")
         expect(result).toEqual(expected)
     })
+
+    test("test parseCsv function with missing data and missing comma", () => {
+        const mockCsvData =
+            "name,age,gender\nJohn,25,Male\nJane,30,Female\n35,Male"
+        fs.readFileSync.mockReturnValue(mockCsvData)
+
+        const expected = [
+            {
+                name: "John",
+                age: "25",
+                gender: "Male"
+            },
+            {
+                name: "Jane",
+                age: "30",
+                gender: "Female"
+            }
+        ]
+
+        const result = parseCsv("some_path")
+        expect(result).toEqual(expected)
+    })
 })


### PR DESCRIPTION
Changes proposed in this PR:

- [Skip invalid rows while parsing](https://github.com/oceanprotocol/df-sql/commit/88ad5faa8ced7bca21c0dc685bad00c09c5f80cc)
- [Set round hash at the end to allow re-try on fail](https://github.com/oceanprotocol/df-sql/commit/701e0b65b8fe1281504128a50a52421960af060a)
- [updateDb now bulk inserts data instead of one by one](https://github.com/oceanprotocol/df-sql/commit/b0c5984e5229ac58a0c2d41b0134a6a7ca306099)
- [Set concurrency to 1 as bulk update is fast enough](https://github.com/oceanprotocol/df-sql/commit/060a523468b7b3ea721c1ef9ad7ce7111f6434d9)